### PR TITLE
Fix: Make Bedrock model IDs region-aware to support non-US regions

### DIFF
--- a/tech-recon/src/agents/llm_st.py
+++ b/tech-recon/src/agents/llm_st.py
@@ -201,15 +201,16 @@ def get_llm_by_type(llm_type: LLMType):
     Get LLM instance by type. Returns cached instance if available.
     """
 
+    region = os.environ.get("AWS_DEFAULT_REGION", None)
     boto3_bedrock = bedrock.get_bedrock_client(
         assumed_role=os.environ.get("BEDROCK_ASSUME_ROLE", None),
         endpoint_url=os.environ.get("BEDROCK_ENDPOINT_URL", None),
-        region=os.environ.get("AWS_DEFAULT_REGION", None),
+        region=region,
     )
 
     if llm_type == "reasoning":
         llm = bedrock_model(
-            model_id=bedrock_info.get_model_id(model_name="Claude-V3-7-Sonnet-CRI"),
+            model_id=bedrock_info.get_model_id(model_name="Claude-V3-7-Sonnet-CRI", region=region),
             bedrock_client=boto3_bedrock,
             stream=True,
             callbacks=[StreamingStdOutCallbackHandler()],
@@ -223,7 +224,7 @@ def get_llm_by_type(llm_type: LLMType):
     elif llm_type == "basic":
         llm = bedrock_model(
             #model_id=bedrock_info.get_model_id(model_name="Nova-Pro-CRI"),
-            model_id=bedrock_info.get_model_id(model_name="Claude-V3-5-V-2-Sonnet-CRI"),
+            model_id=bedrock_info.get_model_id(model_name="Claude-V3-5-V-2-Sonnet-CRI", region=region),
             bedrock_client=boto3_bedrock,
             stream=True,
             callbacks=[StreamingStdOutCallbackHandler()],
@@ -236,7 +237,7 @@ def get_llm_by_type(llm_type: LLMType):
     elif llm_type == "vision":
         llm = bedrock_model(
             #model_id=bedrock_info.get_model_id(model_name="Claude-V3-7-Sonnet-CRI"),
-            model_id=bedrock_info.get_model_id(model_name="Claude-V3-5-V-2-Sonnet-CRI"),
+            model_id=bedrock_info.get_model_id(model_name="Claude-V3-5-V-2-Sonnet-CRI", region=region),
             bedrock_client=boto3_bedrock,
             stream=True,
             callbacks=[StreamingStdOutCallbackHandler()],
@@ -249,7 +250,7 @@ def get_llm_by_type(llm_type: LLMType):
     elif llm_type == "browser":
         llm = ChatBedrock(
             #model_id=bedrock_info.get_model_id(model_name="Claude-V3-7-Sonnet-CRI"),
-            model_id=bedrock_info.get_model_id(model_name="Claude-V3-5-V-2-Sonnet-CRI"),
+            model_id=bedrock_info.get_model_id(model_name="Claude-V3-5-V-2-Sonnet-CRI", region=region),
             client=boto3_bedrock,
             model_kwargs={
                 "max_tokens": 8192,

--- a/tech-recon/src/utils/bedrock.py
+++ b/tech-recon/src/utils/bedrock.py
@@ -166,11 +166,25 @@ class bedrock_info():
             return cls._BEDROCK_MODEL_INFO
 
     @classmethod
-    def get_model_id(cls, model_name):
+    def get_model_id(cls, model_name, region=None):
 
         assert model_name in cls._BEDROCK_MODEL_INFO.keys(), "Check model name"
 
-        return cls._BEDROCK_MODEL_INFO[model_name]
+        base_id = cls._BEDROCK_MODEL_INFO[model_name]
+        
+        # If region is not provided, try to get it from environment variables
+        if region is None:
+            region = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION"))
+        
+        # Handle region-specific model ID prefixes
+        # The 'us.' prefix is only valid for US regions (e.g., us-east-1, us-west-2)
+        # For non-US regions (e.g., eu-west-2, ap-southeast-1), the 'us.' prefix must be removed
+        if region and not region.startswith('us-'):
+            # Non-US region: remove 'us.' prefix if present
+            if base_id.startswith('us.'):
+                base_id = base_id.replace('us.', '', 1)
+        
+        return base_id
     
 class bedrock_model():
 

--- a/tech-recon/src/utils/strands_sdk_utils.py
+++ b/tech-recon/src/utils/strands_sdk_utils.py
@@ -3,6 +3,7 @@
 import logging
 import traceback
 import asyncio
+import os
 from datetime import datetime
 from src.utils.bedrock import bedrock_info
 from strands import Agent
@@ -83,6 +84,7 @@ class strands_utils():
         llm_type = kwargs["llm_type"]
         cache_type = kwargs["cache_type"]
         enable_reasoning = kwargs["enable_reasoning"]
+        region = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION"))
 
         if llm_type in ["claude-sonnet-3-7", "claude-sonnet-4", "claude-sonnet-4-5"]:
             
@@ -92,7 +94,7 @@ class strands_utils():
 
             ## BedrockModel params: https://strandsagents.com/latest/api-reference/models/?h=bedrockmodel#strands.models.bedrock.BedrockModel
             llm = BedrockModel(
-                model_id=bedrock_info.get_model_id(model_name=model_name),
+                model_id=bedrock_info.get_model_id(model_name=model_name, region=region),
                 streaming=True,
                 max_tokens=8192*5,
                 stop_sequences=["\n\nHuman"],
@@ -114,7 +116,7 @@ class strands_utils():
         elif llm_type == "claude-sonnet-3-5-v-2":
             ## BedrockModel params: https://strandsagents.com/latest/api-reference/models/?h=bedrockmodel#strands.models.bedrock.BedrockModel
             llm = BedrockModel(
-                model_id=bedrock_info.get_model_id(model_name="Claude-V4-5-Sonnet"),
+                model_id=bedrock_info.get_model_id(model_name="Claude-V4-5-Sonnet", region=region),
                 streaming=True,
                 max_tokens=8192,
                 stop_sequences=["\n\nHuman"],


### PR DESCRIPTION
## Problem

When using Amazon Bedrock in non-US regions (e.g., `eu-west-2`), the system was failing with a `ValidationException` because model identifiers included a `us.` prefix that is only valid for US regions.

### Error Example
```
ERROR: An error occurred (ValidationException) when calling the ConverseStream operation: 
The provided model identifier is invalid.
└ Bedrock region: eu-west-2
└ Model id: us.anthropic.claude-3-7-sonnet-20250219-v1:0
```

This caused:
- 5 retry attempts to fail for the Tracker agent
- System to fall back to alternative models/agents
- Added ~30-60 seconds of retry attempts
- Blocked proper multi-region support

**Fixes #1**

## Solution

This PR implements region-aware model ID handling that automatically adjusts model identifiers based on the AWS region:

1. **Modified `bedrock_info.get_model_id()`** to accept an optional `region` parameter
2. **Automatic prefix handling**: For non-US regions, the `us.` prefix is automatically stripped from model IDs
3. **Backward compatible**: If region is not provided, it reads from environment variables (`AWS_REGION` or `AWS_DEFAULT_REGION`)
4. **Updated all call sites** to pass the region parameter:
   - `llm_st.py`: Updated all LLM type configurations
   - `strands_sdk_utils.py`: Updated model creation calls

### How It Works

- **For non-US regions** (e.g., `eu-west-2`, `ap-southeast-1`):
  - Model ID: `us.anthropic.claude-3-7-sonnet-20250219-v1:0` → `anthropic.claude-3-7-sonnet-20250219-v1:0`
  
- **For US regions** (e.g., `us-east-1`, `us-west-2`):
  - Model ID: `us.anthropic.claude-3-7-sonnet-20250219-v1:0` (unchanged)

## Changes Made

### Files Modified
- `tech-recon/src/utils/bedrock.py`: Added region-aware logic to `get_model_id()` method
- `tech-recon/src/agents/llm_st.py`: Updated all `get_model_id()` calls to pass region
- `tech-recon/src/utils/strands_sdk_utils.py`: Added region parameter to model ID calls

### Code Changes
```python
# Before
model_id = bedrock_info.get_model_id(model_name="Claude-V3-7-Sonnet-CRI")

# After  
region = os.environ.get("AWS_DEFAULT_REGION", None)
model_id = bedrock_info.get_model_id(model_name="Claude-V3-7-Sonnet-CRI", region=region)
```

## Testing

- ✅ No linting errors
- ✅ Backward compatible (works without region parameter)
- ✅ Automatically handles region from environment variables
- ✅ Fixes the ValidationException for non-US regions

## Impact

- ✅ Resolves issue #1
- ✅ Enables multi-region Bedrock support
- ✅ Eliminates retry failures for Tracker agent
- ✅ Reduces execution time by ~30-60 seconds per run
- ✅ No breaking changes (backward compatible)

## Reference

See `ERROR_SUMMARY.md` for full error details and context.