### PR TITLE
Fix #4: Add botocore[crt] dependency to pyproject.toml

### DIFF
--- a/tech-recon/setup/pyproject.toml
+++ b/tech-recon/setup/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "ipykernel>=6.29.5",
     "jupyter>=1.1.1",
     "boto3>=1.40.51",
+    "botocore[crt]>=1.40.51",
     "strands-agents>=1.12.0",
     "mcp>=1.13.0",
     "streamlit==1.48.1",


### PR DESCRIPTION
## Description

This PR fixes issue #4 by adding the `botocore[crt]` dependency to `pyproject.toml`. This ensures that certificate-based authentication support is automatically installed when setting up the project, preventing the `MissingDependencyException` that occurs when using AWS CLI `aws login` command.

## Changes

- Added `botocore[crt]>=1.40.51` to dependencies in `tech-recon/setup/pyproject.toml`
- Placed alongside other AWS-related dependencies (`boto3` and `awscli`) for better organization

## Impact

- ✅ Prevents `MissingDependencyException` on initial execution
- ✅ Ensures automatic installation of certificate-based authentication support
- ✅ No manual intervention required when setting up the project
- ✅ Future installations via `uv sync` will include this dependency automatically

## Testing

The dependency can be verified by running:
```bash
uv sync
```

This will install all dependencies including `botocore[crt]`, which provides the certificate-based authentication support required for AWS CLI `aws login`.

## Related Issue

Fixes #4

## Reference

See `ERROR_SUMMARY.md` for full error details and context.