### PR TITLE
Fix: Add python-docx dependency to resolve ModuleNotFoundError

### DIFF
--- a/tech-recon/setup/pyproject.toml
+++ b/tech-recon/setup/pyproject.toml
@@ -41,4 +41,5 @@ dependencies = [
     "flask>=3.0.0",
     "flask-socketio>=5.3.0",
     "python-socketio>=5.10.0",
+    "python-docx>=1.1.0",
 ]


### PR DESCRIPTION
## Summary

This PR adds the missing `python-docx` dependency to `pyproject.toml` to fix the `ModuleNotFoundError: No module named 'docx'` that prevents Reporter agents from generating DOCX reports.

## Problem

Without this dependency, when Reporter agents attempt to generate DOCX reports, they encounter:
```
ModuleNotFoundError: No module named 'docx'
```

This prevents the creation of:
- `final_report.docx` (Part 1)
- Technology-specific reports (Part 2)

**Impact:** Users complete the entire analysis workflow but receive no deliverable output, making the tool essentially useless without this fix.

## Solution

Add `python-docx>=1.1.0` to the dependencies list in `tech-recon/setup/pyproject.toml`.

## Changes

- ✅ Added `python-docx>=1.1.0` to dependencies in `pyproject.toml`

## Testing

After merging, users should:
1. Install dependencies: `uv pip install -e .` or `uv sync`
2. Verify import works: `python -c "from docx import Document; print('OK')"`
3. Run Part 1 or Part 2 workflow and confirm DOCX reports are generated successfully

## Related

Fixes #9